### PR TITLE
Feature/fix typo in error handling

### DIFF
--- a/app/com/yetu/oauth2resource/services/tokenvalidation/OAuth2TokenValidationService.scala
+++ b/app/com/yetu/oauth2resource/services/tokenvalidation/OAuth2TokenValidationService.scala
@@ -67,7 +67,7 @@ class OAuth2TokenValidationService(oAuth2ProviderSettings: OAuth2ProviderSetting
       case Success(e) => Future.successful(e)
       case Failure(ex) =>
         Logger.error("Token parse exception, failed to parse token", ex)
-        Future.failed(TokenParseException(ex.getMessage, ex))
+        Future.successful(Left(TokenParseException(ex.getMessage, ex)))
     }
   }
 

--- a/test/com/yetu/oauth2resource/services/tokenvalidation/OAuth2TokenValidationServiceTest.scala
+++ b/test/com/yetu/oauth2resource/services/tokenvalidation/OAuth2TokenValidationServiceTest.scala
@@ -33,8 +33,8 @@ class OAuth2TokenValidationServiceTest extends BaseSpec with Matchers with Route
   }
 
   "Validation service" should "validate reject wrong token (not jwt)" in {
-    whenReady(tokenValidationService.validate(Some(wrongToken), JWTTokenMethod()).failed) { e =>
-      e shouldBe a [TokenParseException]
+    whenReady(tokenValidationService.validate(Some(wrongToken), JWTTokenMethod())) { either =>
+      either should be('left)
     }
   }
 


### PR DESCRIPTION
Changed a way how we handle errors in OAuthTokenValidationService. POssibly we need get rid of Either.
